### PR TITLE
Artur game simplifications

### DIFF
--- a/Assets/!/Prefabs/Enemies/Boss1.prefab
+++ b/Assets/!/Prefabs/Enemies/Boss1.prefab
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.026417255, y: -0.028102756}

--- a/Assets/!/Prefabs/Enemies/Boss1.prefab
+++ b/Assets/!/Prefabs/Enemies/Boss1.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 1345167096}
   - component: {fileID: 1631889372180872059}
   - component: {fileID: -6591276275038885113}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Boss1
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.026417255, y: -0.028102756}

--- a/Assets/!/Prefabs/Enemies/Boss1.prefab
+++ b/Assets/!/Prefabs/Enemies/Boss1.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 1345167097}
   - component: {fileID: 1345167096}
   - component: {fileID: 1631889372180872059}
+  - component: {fileID: -6591276275038885113}
   m_Layer: 0
   m_Name: Boss1
   m_TagString: Enemy
@@ -97,7 +98,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7375728346704147026}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9a831207d95adec9e8c98e1c0c7e1d48, type: 3}
   m_Name: 
@@ -204,3 +205,16 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &-6591276275038885113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7375728346704147026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 728a1e2da87eeb445bc763cf8123169a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StatsSO: {fileID: 11400000, guid: 8e36868878a360f7ab070f747718fced, type: 2}

--- a/Assets/!/Prefabs/Enemies/Zombie1.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie1.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 1345167096}
   - component: {fileID: 1631889372180872059}
   - component: {fileID: 6255973921551161247}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Zombie1
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.026417255, y: -0.028102756}

--- a/Assets/!/Prefabs/Enemies/Zombie1.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie1.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 1345167097}
   - component: {fileID: 1345167096}
   - component: {fileID: 1631889372180872059}
+  - component: {fileID: 6255973921551161247}
   m_Layer: 0
   m_Name: Zombie1
   m_TagString: Enemy
@@ -97,7 +98,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7375728346704147026}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9a831207d95adec9e8c98e1c0c7e1d48, type: 3}
   m_Name: 
@@ -204,3 +205,16 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &6255973921551161247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7375728346704147026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 728a1e2da87eeb445bc763cf8123169a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StatsSO: {fileID: 11400000, guid: 8e36868878a360f7ab070f747718fced, type: 2}

--- a/Assets/!/Prefabs/Enemies/Zombie1.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie1.prefab
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.026417255, y: -0.028102756}

--- a/Assets/!/Prefabs/Enemies/Zombie2.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie2.prefab
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: -0.037701726, y: -0.068184376}

--- a/Assets/!/Prefabs/Enemies/Zombie2.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie2.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 6066341481304386788}
   - component: {fileID: 4599625978148104503}
   - component: {fileID: -4985492000363082492}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Zombie2
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: -0.037701726, y: -0.068184376}

--- a/Assets/!/Prefabs/Enemies/Zombie2.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie2.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 6066341481304386791}
   - component: {fileID: 6066341481304386788}
   - component: {fileID: 4599625978148104503}
+  - component: {fileID: -4985492000363082492}
   m_Layer: 0
   m_Name: Zombie2
   m_TagString: Enemy
@@ -97,7 +98,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6066341481304386814}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9a831207d95adec9e8c98e1c0c7e1d48, type: 3}
   m_Name: 
@@ -204,3 +205,16 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &-4985492000363082492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6066341481304386814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 728a1e2da87eeb445bc763cf8123169a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StatsSO: {fileID: 11400000, guid: 8e36868878a360f7ab070f747718fced, type: 2}

--- a/Assets/!/Prefabs/Enemies/Zombie3.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie3.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 8565416094436821006}
   - component: {fileID: 8565416094436821007}
   - component: {fileID: -6016515470377485071}
+  - component: {fileID: -9216070732752533692}
   m_Layer: 0
   m_Name: Zombie3
   m_TagString: Enemy
@@ -97,7 +98,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8565416094436821001}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9a831207d95adec9e8c98e1c0c7e1d48, type: 3}
   m_Name: 
@@ -204,3 +205,16 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &-9216070732752533692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8565416094436821001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 728a1e2da87eeb445bc763cf8123169a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StatsSO: {fileID: 11400000, guid: 8e36868878a360f7ab070f747718fced, type: 2}

--- a/Assets/!/Prefabs/Enemies/Zombie3.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie3.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 8565416094436821007}
   - component: {fileID: -6016515470377485071}
   - component: {fileID: -9216070732752533692}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Zombie3
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: -0.026120365, y: -0.03789997}

--- a/Assets/!/Prefabs/Enemies/Zombie3.prefab
+++ b/Assets/!/Prefabs/Enemies/Zombie3.prefab
@@ -150,7 +150,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: -0.026120365, y: -0.03789997}

--- a/Assets/!/Prefabs/Player.prefab
+++ b/Assets/!/Prefabs/Player.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &2817682900796868583
+--- !u!1 &1883995756431047132
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,16 +8,76 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2817682900796868573}
-  - component: {fileID: 2817682900796868572}
-  - component: {fileID: 2817682900796868575}
-  - component: {fileID: 2817682900796868574}
-  - component: {fileID: 2817682900796868577}
-  - component: {fileID: 2817682900796868576}
-  - component: {fileID: 2817682900796868579}
-  - component: {fileID: 2817682900796868578}
-  - component: {fileID: 2817682900796868581}
-  - component: {fileID: 2817682900796868580}
+  - component: {fileID: 1367865074660624309}
+  - component: {fileID: 8339285421226734810}
+  - component: {fileID: 8319330090714341783}
+  m_Layer: 7
+  m_Name: OccludableCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1367865074660624309
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883995756431047132}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6530764336699020583}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!70 &8339285421226734810
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883995756431047132}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.031839553, y: -0.52453876}
+  m_Size: {x: 0.99626017, y: 1.2635305}
+  m_Direction: 0
+--- !u!114 &8319330090714341783
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883995756431047132}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fd6e6cadbb74734fbb74cc386f55c12, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2953103380354660242
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6530764336699020583}
+  - component: {fileID: 5043508670358120955}
+  - component: {fileID: 791566273745220735}
+  - component: {fileID: 3903148779770245549}
+  - component: {fileID: 4650440590032395249}
+  - component: {fileID: 4148824851980919230}
+  - component: {fileID: 4386068080982919703}
+  - component: {fileID: 4804763064453170230}
+  - component: {fileID: 2970768599229368143}
   m_Layer: 7
   m_Name: Player
   m_TagString: Player
@@ -25,29 +85,30 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2817682900796868573
+--- !u!4 &6530764336699020583
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 2953103380354660242}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.000061035156, y: 0, z: 0}
   m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2817682901183718010}
+  - {fileID: 1367865074660624309}
+  - {fileID: 9059980465878767505}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2817682900796868572
+--- !u!212 &5043508670358120955
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -93,14 +154,14 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!50 &2817682900796868575
+--- !u!50 &791566273745220735
 Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -114,14 +175,14 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!96 &2817682900796868574
+--- !u!96 &3903148779770245549
 TrailRenderer:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -222,13 +283,13 @@ TrailRenderer:
   m_MinVertexDistance: 0.1
   m_Autodestruct: 0
   m_Emitting: 0
---- !u!61 &2817682900796868577
+--- !u!61 &4650440590032395249
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -248,13 +309,13 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.7974135, y: 0.3342086}
   m_EdgeRadius: 0
---- !u!114 &2817682900796868576
+--- !u!114 &4148824851980919230
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
@@ -272,7 +333,7 @@ MonoBehaviour:
   m_ControlsChangedEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2817682900796868579}
+      - m_Target: {fileID: 4386068080982919703}
         m_TargetAssemblyTypeName: PlayerControllerV3, Assembly-CSharp
         m_MethodName: OnDeviceChange
         m_Mode: 0
@@ -287,7 +348,7 @@ MonoBehaviour:
   m_ActionEvents:
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2817682900796868579}
+      - m_Target: {fileID: 4386068080982919703}
         m_TargetAssemblyTypeName: PlayerControllerV3, Assembly-CSharp
         m_MethodName: OnMove
         m_Mode: 0
@@ -303,7 +364,7 @@ MonoBehaviour:
     m_ActionName: Player/Move[/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2817682900796868579}
+      - m_Target: {fileID: 4386068080982919703}
         m_TargetAssemblyTypeName: PlayerControllerV3, Assembly-CSharp
         m_MethodName: OnUseWeapon
         m_Mode: 0
@@ -319,7 +380,7 @@ MonoBehaviour:
     m_ActionName: Player/Fire Gun[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2817682900796868579}
+      - m_Target: {fileID: 4386068080982919703}
         m_TargetAssemblyTypeName: PlayerControllerV3, Assembly-CSharp
         m_MethodName: OnAimWeapon
         m_Mode: 0
@@ -335,7 +396,7 @@ MonoBehaviour:
     m_ActionName: Player/Aim Gun[/Mouse/position]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2817682900796868579}
+      - m_Target: {fileID: 4386068080982919703}
         m_TargetAssemblyTypeName: PlayerControllerV3, Assembly-CSharp
         m_MethodName: OnAbility1
         m_Mode: 0
@@ -351,7 +412,7 @@ MonoBehaviour:
     m_ActionName: Player/Ability1[/Keyboard/leftShift]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2817682900796868579}
+      - m_Target: {fileID: 4386068080982919703}
         m_TargetAssemblyTypeName: PlayerControllerV3, Assembly-CSharp
         m_MethodName: OnAbility2
         m_Mode: 0
@@ -367,7 +428,7 @@ MonoBehaviour:
     m_ActionName: Player/Ability2[/Keyboard/space]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2817682900796868579}
+      - m_Target: {fileID: 4386068080982919703}
         m_TargetAssemblyTypeName: PlayerControllerV3, Assembly-CSharp
         m_MethodName: OnAbility3
         m_Mode: 0
@@ -386,20 +447,20 @@ MonoBehaviour:
   m_DefaultActionMap: Player
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
---- !u!114 &2817682900796868579
+--- !u!114 &4386068080982919703
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dff0de03dca011a4aa07f0f218522104, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  rb: {fileID: 2817682900796868575}
-  tr: {fileID: 2817682900796868574}
+  rb: {fileID: 791566273745220735}
+  tr: {fileID: 3903148779770245549}
   coinAmountSO: {fileID: 11400000, guid: 634297763070f894ea1153d77f083a58, type: 2}
   DefaultWeapon: {fileID: 6820678582435311943, guid: c54473dbcd67c5e4e8aaae0b42bc3e16, type: 3}
   WeaponPlayerDistance: 1.5
@@ -407,16 +468,16 @@ MonoBehaviour:
   _flashAmount: 10
   _moveSpeed: 10
   enemyPositionFromPlayerSO: {fileID: 11400000, guid: d64592d1909474c4ab1d2f83c0048486, type: 2}
-  cr: {fileID: 2817682900796868580}
+  cr: {fileID: 0}
   autoAimRangeSO: {fileID: 11400000, guid: d5142216f01d41648bc8a07e748c9b7a, type: 2}
---- !u!95 &2817682900796868578
+--- !u!95 &4804763064453170230
 Animator:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
   m_Controller: {fileID: 9100000, guid: 8b28f564bf53e8a46853e969a33ee7ae, type: 2}
@@ -429,13 +490,13 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!114 &2817682900796868581
+--- !u!114 &2970768599229368143
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 2953103380354660242}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e1a083b0f99d21e48a00c271baee82dc, type: 3}
@@ -444,15 +505,46 @@ MonoBehaviour:
   coinAmountSO: {fileID: 11400000, guid: 634297763070f894ea1153d77f083a58, type: 2}
   xpAmountSO: {fileID: 11400000, guid: 63830cec319fab99b9d424b2d3610e20, type: 2}
   BrowniePointsSO: {fileID: 11400000, guid: ddccb5130fb25484fac644eb2092f538, type: 2}
-  coinAmount: 0
-  _xpAmmount: 0
---- !u!58 &2817682900796868580
+--- !u!1 &9059980465878767504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9059980465878767505}
+  - component: {fileID: 9059980465878767507}
+  - component: {fileID: 9059980465878767506}
+  m_Layer: 7
+  m_Name: AutoAimCollider
+  m_TagString: AutoAim
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9059980465878767505
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9059980465878767504}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6530764336699020583}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &9059980465878767507
 CircleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682900796868583}
+  m_GameObject: {fileID: 9059980465878767504}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -461,65 +553,17 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 2
---- !u!1 &2817682901183718013
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2817682901183718010}
-  - component: {fileID: 2817682901183718008}
-  - component: {fileID: 2817682901183718011}
-  m_Layer: 7
-  m_Name: OccludableCollider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2817682901183718010
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682901183718013}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2817682900796868573}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!70 &2817682901183718008
-CapsuleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682901183718013}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.031839553, y: -0.52453876}
-  m_Size: {x: 0.99626017, y: 1.2635305}
-  m_Direction: 0
---- !u!114 &2817682901183718011
+  m_Radius: 0.5
+--- !u!114 &9059980465878767506
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2817682901183718013}
+  m_GameObject: {fileID: 9059980465878767504}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fd6e6cadbb74734fbb74cc386f55c12, type: 3}
+  m_Script: {fileID: 11500000, guid: f26a7c7278fa2b149a22237cc2c13298, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cr: {fileID: 9059980465878767507}

--- a/Assets/!/Scenes/GameScene.unity
+++ b/Assets/!/Scenes/GameScene.unity
@@ -224,7 +224,7 @@ RectTransform:
   - {fileID: 229520655}
   - {fileID: 888649256}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -341,6 +341,46 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4055552236110293305, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552236184062276, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552236216428386, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552236482452340, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552236521663535, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552236851330768, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552236885639120, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552236899284881, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237079663026, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237144498523, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4055552237243870216, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
       propertyPath: m_Points.m_Paths.Array.data[0].Array.size
       value: 15
@@ -457,13 +497,65 @@ PrefabInstance:
       propertyPath: m_Points.m_Paths.Array.data[0].Array.data[14].y
       value: 1.1650215
       objectReference: {fileID: 0}
+    - target: {fileID: 4055552237243870221, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237254315023, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237288794042, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237312758597, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237349413882, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237375325248, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237416831103, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237499468325, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237556712297, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237604795290, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237671994250, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237690862255, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552237725915546, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4055552237850799537, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
       propertyPath: m_Name
       value: EmptyMap 8x
       objectReference: {fileID: 0}
     - target: {fileID: 4055552237850799539, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4055552237850799539, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
       propertyPath: m_LocalPosition.x
@@ -505,6 +597,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4055552238098391584, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552238123192990, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552238124821056, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055552238196342228, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
 --- !u!1 &229520654 stripped
@@ -531,54 +639,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_MovementRange: 30
   m_ControlPath: <Gamepad>/leftStick
---- !u!1 &294406330
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 294406331}
-  - component: {fileID: 294406334}
-  m_Layer: 3
-  m_Name: PathfindingGrid
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &294406331
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 294406330}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1279452660}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &294406334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 294406330}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3836c4dfaf0fc7c079713f98ece07128, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  gridWorldSize: {x: 100, y: 100}
-  allowDiagonals: 0
-  map: {fileID: 1712425179}
-  showGrid: 1
 --- !u!1001 &471971830
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1164,50 +1224,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 1, y: 1}
---- !u!1 &1073015016
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1073015018}
-  - component: {fileID: 1073015017}
-  m_Layer: 6
-  m_Name: Grid
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!156049354 &1073015017
-Grid:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073015016}
-  m_Enabled: 1
-  m_CellSize: {x: 1, y: 1, z: 0}
-  m_CellGap: {x: 0, y: 0, z: 0}
-  m_CellLayout: 0
-  m_CellSwizzle: 0
---- !u!4 &1073015018
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073015016}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1111076775 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
@@ -1282,51 +1298,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
---- !u!1 &1279452658
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1279452660}
-  - component: {fileID: 1279452659}
-  m_Layer: 0
-  m_Name: Grid (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!156049354 &1279452659
-Grid:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1279452658}
-  m_Enabled: 1
-  m_CellSize: {x: 1, y: 1, z: 0}
-  m_CellGap: {x: 0, y: 0, z: 0}
-  m_CellLayout: 0
-  m_CellSwizzle: 0
---- !u!4 &1279452660
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1279452658}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 294406331}
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1403691030
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1396,11 +1367,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
---- !u!1 &1712425179 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4055552237850799537, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
-  m_PrefabInstance: {fileID: 204694575}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1926644000
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1717,13 +1683,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 791566273745220735, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_Simulated
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2953103380354660242, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 4650440590032395249, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_IsTrigger
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/!/Scenes/GameScene.unity
+++ b/Assets/!/Scenes/GameScene.unity
@@ -632,7 +632,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5493358297040060898, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5493358297040060898, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: spawnLocations.Array.data[0]
@@ -1206,7 +1206,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1111076775 stripped
 Transform:
@@ -1721,13 +1721,9 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/!/Scenes/GameScene.unity
+++ b/Assets/!/Scenes/GameScene.unity
@@ -1710,76 +1710,68 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2061555289}
   m_CullTransparentMesh: 1
---- !u!1001 &2817682899744204478
+--- !u!1001 &9059980465268470680
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.000061035156
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868573, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817682900796868583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+    - target: {fileID: 2953103380354660242, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    - target: {fileID: 2817682901183718008, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_Size.x
-      value: 0.99626017
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2817682901183718008, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_Size.y
-      value: 1.2635305
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 2817682901183718008, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_Offset.x
-      value: 0.031839553
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.000061035156
       objectReference: {fileID: 0}
-    - target: {fileID: 2817682901183718008, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
-      propertyPath: m_Offset.y
-      value: -0.52453876
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9059980465878767507, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}

--- a/Assets/!/Scenes/GameScene.unity
+++ b/Assets/!/Scenes/GameScene.unity
@@ -224,7 +224,7 @@ RectTransform:
   - {fileID: 229520655}
   - {fileID: 888649256}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -463,7 +463,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4055552237850799539, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 4055552237850799539, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
       propertyPath: m_LocalPosition.x
@@ -588,7 +588,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2959325123100305180, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2959325123100305180, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: m_LocalPosition.x
@@ -632,7 +632,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5493358297040060898, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5493358297040060898, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: spawnLocations.Array.data[0]
@@ -714,7 +714,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &710190632 stripped
 Transform:
@@ -1206,7 +1206,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1111076775 stripped
 Transform:
@@ -1230,7 +1230,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_LocalScale.x
@@ -1325,7 +1325,7 @@ Transform:
   m_Children:
   - {fileID: 294406331}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1403691030
 PrefabInstance:
@@ -1344,7 +1344,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_LocalScale.x
@@ -1396,63 +1396,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
---- !u!1001 &1568358631
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7375728346704147026, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_Name
-      value: Zombie1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.840175
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.1870575
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
 --- !u!1 &1712425179 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4055552237850799537, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}
@@ -1780,7 +1723,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 6530764336699020583, guid: 14cd9baaf05b1564cbaba086d853f415, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/!/Scenes/GameScene.unity
+++ b/Assets/!/Scenes/GameScene.unity
@@ -224,7 +224,7 @@ RectTransform:
   - {fileID: 229520655}
   - {fileID: 888649256}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -588,7 +588,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2959325123100305180, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 2959325123100305180, guid: a1d01ac2e1ed336468555ef1c12726ad, type: 3}
       propertyPath: m_LocalPosition.x
@@ -714,7 +714,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &710190632 stripped
 Transform:
@@ -1206,7 +1206,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1111076775 stripped
 Transform:
@@ -1230,7 +1230,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_LocalScale.x
@@ -1325,7 +1325,7 @@ Transform:
   m_Children:
   - {fileID: 294406331}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1403691030
 PrefabInstance:
@@ -1344,7 +1344,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2449894066712452996, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
       propertyPath: m_LocalScale.x
@@ -1396,6 +1396,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d76c1b04dd52a21458f31e4a7a20db10, type: 3}
+--- !u!1001 &1568358631
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7375728346704147026, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_Name
+      value: Zombie1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.840175
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.1870575
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375728346704147031, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 60f573493f8b1c5489464264d6c9f99e, type: 3}
 --- !u!1 &1712425179 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4055552237850799537, guid: 548e33a2b3f0d804981cf0fcf8944b12, type: 3}

--- a/Assets/!/ScriptableObjects/Session/AutoAimRange.asset
+++ b/Assets/!/ScriptableObjects/Session/AutoAimRange.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfaf3db1a4a505e4faea8f74b057248c, type: 3}
   m_Name: AutoAimRange
   m_EditorClassIdentifier: 
-  Value: 7
+  Value: 10
   IsNull: 0

--- a/Assets/!/Scripts/Enemy/EnemyMovement.cs
+++ b/Assets/!/Scripts/Enemy/EnemyMovement.cs
@@ -23,7 +23,6 @@ namespace Assets.Scripts
         private Animator _animator;
         private SpriteRenderer _spriteRenderer;
         private Rigidbody2D _rb;
-        //private EnemyStats _enemyStats;
 
         void Start()
         {
@@ -34,7 +33,6 @@ namespace Assets.Scripts
             _animator = GetComponent<Animator>();
             _spriteRenderer = GetComponent<SpriteRenderer>();
             _rb = GetComponent<Rigidbody2D>();
-            //_enemyStats = GetComponent<EnemyStats>();
             _speed = StatsSO.CurrentStats.MovementSpeed;
             _reachDistance = StatsSO.CurrentStats.AttackRange;
         }

--- a/Assets/!/Scripts/Enemy/EnemyMovementV2.cs
+++ b/Assets/!/Scripts/Enemy/EnemyMovementV2.cs
@@ -28,8 +28,6 @@ public class EnemyMovementV2 : MonoBehaviour
     // Update is called once per frame
     void FixedUpdate()
     {
-        //_animator.SetBool("isMoving", false);
-        //_rb.velocity = Vector2.zero;
 
         _animator.SetBool("isMoving", true);
 
@@ -39,11 +37,19 @@ public class EnemyMovementV2 : MonoBehaviour
         transform.position = Vector2.MoveTowards(this.transform.position, _player.transform.position, _speed * Time.deltaTime);
 
         if (direction.x > 0)
+        {
             _spriteRenderer.flipX = true;
+        }
+
         else
+        {
             _spriteRenderer.flipX = false;
+        }
 
-
-
+        if (_rb.IsSleeping())
+        {
+            _animator.SetBool("isMoving", false);
+            _rb.velocity = Vector2.zero;
+        }
     }
 }

--- a/Assets/!/Scripts/Enemy/EnemyMovementV2.cs
+++ b/Assets/!/Scripts/Enemy/EnemyMovementV2.cs
@@ -1,0 +1,49 @@
+using Assets.Scripts.AStar;
+using Assets.Scripts.Stats;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyMovementV2 : MonoBehaviour
+{
+    public StatsSO StatsSO;
+    private float _speed;
+    private GameObject _player;
+    private Animator _animator;
+    private SpriteRenderer _spriteRenderer;
+    private Rigidbody2D _rb;
+    private float distance; 
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        _player = GameObject.FindWithTag("Player");
+        _animator = GetComponent<Animator>();
+        _spriteRenderer = GetComponent<SpriteRenderer>();
+        _rb = GetComponent<Rigidbody2D>();
+        _speed = StatsSO.CurrentStats.MovementSpeed;
+    }
+
+
+    // Update is called once per frame
+    void FixedUpdate()
+    {
+        //_animator.SetBool("isMoving", false);
+        //_rb.velocity = Vector2.zero;
+
+        _animator.SetBool("isMoving", true);
+
+        distance = Vector2.Distance(transform.position, _player.transform.position);
+        Vector2 direction = _player.transform.position - transform.position;
+        
+        transform.position = Vector2.MoveTowards(this.transform.position, _player.transform.position, _speed * Time.deltaTime);
+
+        if (direction.x > 0)
+            _spriteRenderer.flipX = true;
+        else
+            _spriteRenderer.flipX = false;
+
+
+
+    }
+}

--- a/Assets/!/Scripts/Enemy/EnemyMovementV2.cs.meta
+++ b/Assets/!/Scripts/Enemy/EnemyMovementV2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 728a1e2da87eeb445bc763cf8123169a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/!/Scripts/Gun/GunBase.cs
+++ b/Assets/!/Scripts/Gun/GunBase.cs
@@ -172,7 +172,7 @@ namespace Assets.Scripts.Gun
 
                 // We need to ignore the player colliders 
                 var raycastHit = Physics2D.RaycastAll(muzzlePosition, direction, _bulletShootDistance)
-                    .FirstOrDefault(x => !string.Equals(x.collider.tag, "Player"));
+                    .FirstOrDefault(x => !string.Equals(x.collider.tag, "AutoAim") && !string.Equals(x.collider.tag, "Player"));
 
                 if (raycastHit.collider != null)
                 { // if we have hit a surface then spawn trail

--- a/Assets/!/Scripts/Player/AutoAimCollider.cs
+++ b/Assets/!/Scripts/Player/AutoAimCollider.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AutoAimCollider : MonoBehaviour
+{
+    public Action<Collider2D> OnTriggerStay2D_Action;
+    public CircleCollider2D cr;
+
+    void OnTriggerStay2D(Collider2D collision)
+    {
+        OnTriggerStay2D_Action?.Invoke(collision);
+    }
+
+}

--- a/Assets/!/Scripts/Player/AutoAimCollider.cs.meta
+++ b/Assets/!/Scripts/Player/AutoAimCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f26a7c7278fa2b149a22237cc2c13298
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/!/Scripts/Player/PlayerControllerV3.cs
+++ b/Assets/!/Scripts/Player/PlayerControllerV3.cs
@@ -40,10 +40,10 @@ public class PlayerControllerV3 : MonoBehaviour, PlayerInputActions.IPlayerActio
 
     private GameObject _playerHandsGameObject;
     public Vector3VariableSO enemyPositionFromPlayerSO;
-    public CircleCollider2D cr;
     public FloatVariableSO autoAimRangeSO;
 
     private OccludableCollider occludableCollider;
+    private AutoAimCollider autoAimCollider;
 
     /// <summary>
     /// This is the player hand object that has a weapon as a child object which rotates around the player
@@ -64,6 +64,9 @@ public class PlayerControllerV3 : MonoBehaviour, PlayerInputActions.IPlayerActio
         occludableCollider.OnTriggerEnter2D_Action += OccludableCollider_OnCollisionEnter2D;
         occludableCollider.OnTriggerExit2D_Action += OccludableCollider_OnCollisionExit2D;
 
+        autoAimCollider = transform.Find("AutoAimCollider").GetComponent<AutoAimCollider>();
+        autoAimCollider.OnTriggerStay2D_Action += AutoAimCollider_OnTriggerStay2D;
+
         animator = GetComponent<Animator>();
         spriteRenderer = GetComponent<SpriteRenderer>();
 
@@ -72,8 +75,9 @@ public class PlayerControllerV3 : MonoBehaviour, PlayerInputActions.IPlayerActio
         //setting the target of the camera to the player
         Camera.main.GetComponent<PlayerCamera>().setTarget(gameObject.transform);
 
-        //sets the radius of the Circle Colider to the value of autoAimtRandeSO. This value will be modified by each of the guns, meaning each gun will have a different autoaim range. At some point i should do this in the update method to make it more dynamic by having the value change mid game. 
-        cr.radius = autoAimRangeSO.Value;  
+        //sets the radius of the AutoAim Colider to the value of autoAimtRandeSO. This value will be modified by each of the guns, meaning each gun will have a different autoaim range. At some point i should do this in the update method to make it more dynamic by having the value change mid game. 
+
+        autoAimCollider.cr.radius = autoAimRangeSO.Value;
     }
 
     void Update()
@@ -99,6 +103,15 @@ public class PlayerControllerV3 : MonoBehaviour, PlayerInputActions.IPlayerActio
     /// the trigger, makes the gun shoot and engages the auto aim.
     /// </summary>
     private void OnTriggerStay2D(Collider2D collision)
+    {
+        if (collision.tag == "Enemy" && _manualAim == false)
+        {
+            UseWeapon();
+            AutoAim(enemyPositionFromPlayerSO.Value);
+        }
+    }
+
+    private void AutoAimCollider_OnTriggerStay2D(Collider2D collision)
     {
         if (collision.tag == "Enemy" && _manualAim == false)
         {

--- a/Assets/!/Sprites/Collectables/Brownie2D.png.meta
+++ b/Assets/!/Sprites/Collectables/Brownie2D.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 81ba3d67c20cdf24f90c3f66c834e449
+guid: 82fdef98c59f4274c88d6c3570de4ed2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -102,7 +102,19 @@ TextureImporter:
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
-    buildTarget: WebGL
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: fffdfffffffdfffffffdfffffffdfffffffdfffffffdfffffffdfffffffffffffffdffff80feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: fffdfffffffdfffffffdfffffffdfffffffdfffffffdfffffffdfffffffeffff7ffdffff80feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - SortOrderSet2
   - SortOrderSet11
   - SetSortLayerForeground
+  - AutoAim
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
-Removed auto aim collider from the player object and instead added it to an empty object that is a child of the player.
-Replaced A* algo with a simple movetowards function means there is no lag now.
-Made the annimations for zombies work the same was as in the old enemy movement script.
-Made the enemy layer and player layer not block each other when walking.
